### PR TITLE
Adicionado metodo de deixar o diretorio dos elementos flexivel

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,5 +13,6 @@ Configure::write('Theme', [
         'show_remember' => true,
         'show_register' => true,
         'show_social' => true
-    ]
+    ],
+    'folder' => ROOT
 ]);

--- a/src/Template/Element/aside-control-sidebar.ctp
+++ b/src/Template/Element/aside-control-sidebar.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside-control-sidebar.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside-control-sidebar.ctp';
 if (file_exists($file)) {
     ob_start();
     include_once $file;

--- a/src/Template/Element/aside-main-sidebar.ctp
+++ b/src/Template/Element/aside-main-sidebar.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside-main-sidebar.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside-main-sidebar.ctp';
 
 if (file_exists($file)) {
     ob_start();

--- a/src/Template/Element/aside/form.ctp
+++ b/src/Template/Element/aside/form.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'form.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'form.ctp';
 
 if (file_exists($file)) {
     ob_start();

--- a/src/Template/Element/aside/sidebar-menu.ctp
+++ b/src/Template/Element/aside/sidebar-menu.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'sidebar-menu.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'sidebar-menu.ctp';
 
 if (file_exists($file)) {
     ob_start();

--- a/src/Template/Element/aside/user-panel.ctp
+++ b/src/Template/Element/aside/user-panel.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'user-panel.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'aside' . DS . 'user-panel.ctp';
 
 if (file_exists($file)) {
     ob_start();

--- a/src/Template/Element/footer.ctp
+++ b/src/Template/Element/footer.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'footer.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'footer.ctp';
 
 if (file_exists($file)) {
     ob_start();

--- a/src/Template/Element/nav-top.ctp
+++ b/src/Template/Element/nav-top.ctp
@@ -1,5 +1,5 @@
 <?php
-$file = ROOT . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'nav-top.ctp';
+$file = $theme['folder'] . DS . 'src' . DS . 'Template' . DS . 'Element' . DS . 'nav-top.ctp';
 
 if (file_exists($file)) {
     ob_start();


### PR DESCRIPTION
Adicionei essa configuração pois foi necessário para mim, uma vez que estou desenvolvendo o painel administrativo dentro de um plugin e mesmo referenciando o tema para o plugin do AdminLTE, ele buscava os elementos dentro do diretorio root.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/132617118856635/199622678249214)
