### PR TITLE
Deprecation notices cake 37

### DIFF
--- a/src/Template/Layout/boxed.ctp
+++ b/src/Template/Layout/boxed.ctp
@@ -96,7 +96,7 @@
             size: "3px"
         }).css("width", "100%");
 
-        var a = $('a[href="<?php echo $this->request->webroot . $this->request->url ?>"]');
+        var a = $('a[href="<?php echo $this->request->getAttribute('webroot') . $this->request->getPath() ?>"]');
         if (!a.parent().hasClass('treeview')) {
             a.parent().addClass('active').parents('.treeview').addClass('active');
         }

--- a/src/Template/Layout/collapsed.ctp
+++ b/src/Template/Layout/collapsed.ctp
@@ -94,7 +94,7 @@
             size: "3px"
         }).css("width", "100%");
 
-        var a = $('a[href="<?php echo $this->request->webroot . $this->request->url ?>"]');
+        var a = $('a[href="<?php echo $this->request->getAttribute('webroot') . $this->request->getPath() ?>"]');
         if (!a.parent().hasClass('treeview')) {
             a.parent().addClass('active').parents('.treeview').addClass('active');
         }

--- a/src/Template/Layout/fixed.ctp
+++ b/src/Template/Layout/fixed.ctp
@@ -96,7 +96,7 @@
             size: "3px"
         }).css("width", "100%");
 
-        var a = $('a[href="<?php echo $this->request->webroot . $this->request->url ?>"]');
+        var a = $('a[href="<?php echo $this->request->getAttribute('webroot') . $this->request->getPath() ?>"]');
         if (!a.parent().hasClass('treeview')) {
             a.parent().addClass('active').parents('.treeview').addClass('active');
         }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -69,6 +69,12 @@ class FormHelper extends CakeFormHelper {
         return parent::submit($caption, $options);
     }
 
+    /**
+     * 
+     * {@inheritDoc}
+     * @see \Cake\View\Helper\FormHelper::input()
+     * @deprecated 1.1.1 Use FormHelper::control() instead, due to \Cake\View\Helper\FormHelper::input() deprecation 
+     */
     public function input($fieldName, array $options = [])
     {
 
@@ -91,7 +97,7 @@ class FormHelper extends CakeFormHelper {
 
         $options += $_options;
 
-        return parent::input($fieldName, $options);
+        return parent::control($fieldName, $options);
     }
 	public function control($fieldName, array $options = [])
 	{


### PR DESCRIPTION
# Motivation

I have a CakePHP 3 website running AdminLTE. Recently upgraded to 3.7 version of the framework, and this deprecation notices appeared in my controller test cases:

```
Deprecated Error: FormHelper::input() is deprecated. Use FormHelper::control() instead. - C:\xampp\htdocs\idscentral\vendor\maiconpinto\cakephp-adminlte-theme\src\View\Helper\FormHelper.php, line: 94
 You can disable deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED` in your config/app.php. in [C:\xampp\htdocs\idscentral\vendor\cakephp\cakephp\src\Core\functions.php, line 311]
```

```
Deprecated Error: Accessing `webroot` as a property will be removed in 4.0.0. Use request->getAttribute("webroot") instead. - C:\xampp\htdocs\idscentral\vendor\maiconpinto\cakephp-adminlte-theme\src\Template\Layout\collapsed.ctp, line: 97
 You can disable deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED` in your config/app.php. in [C:\xampp\htdocs\idscentral\vendor\cakephp\cakephp\src\Core\functions.php, line 311]
```

```
Deprecated Error: Accessing `url` as a property will be removed in 4.0.0. Use request->getPath() instead. - C:\xampp\htdocs\idscentral\vendor\maiconpinto\cakephp-adminlte-theme\src\Template\Layout\collapsed.ctp, line: 97
 You can disable deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED` in your config/app.php. in [C:\xampp\htdocs\idscentral\vendor\cakephp\cakephp\src\Core\functions.php, line 311]
```

# Resolution strategy

For the first of the deprecation notices, I chose to:
1) Use the recommended method in the input() method
2) Mark input() for deprecation, in order to move the deprecation notices to the template files

For the second and third notices, I just replaced old calls with the recommended ones.
