### PR TITLE
Access keys and keyboard shortcuts

### DIFF
--- a/src/Template/Bake/Element/form.twig
+++ b/src/Template/Bake/Element/form.twig
@@ -71,7 +71,7 @@
             </div>
             <!-- /.box-body -->
 
-          <?php echo $this->Form->submit(__('Submit')); ?>
+          <?php echo $this->Form->submit(__('Submit'), ['accesskey' => 's']); ?>
 
           <?php echo $this->Form->end(); ?>
         </div>

--- a/src/Template/Bake/Template/index.twig
+++ b/src/Template/Bake/Template/index.twig
@@ -19,7 +19,7 @@
   <h1>
     {{ pluralHumanName }}
 
-    <div class="pull-right"><?php echo $this->Html->link(__('New'), ['action' => 'add'], ['class'=>'btn btn-success btn-xs']) ?></div>
+    <div class="pull-right"><?php echo $this->Html->link(__('New'), ['action' => 'add', 'accesskey' => 'n'], ['class'=>'btn btn-success btn-xs']) ?></div>
   </h1>
 </section>
 


### PR DESCRIPTION
Hi,

I think a good functionality in any software is to provide keyboard shortcuts, in order to give more options to users and to learn faster ways to operate.
With that in mind, this pull requests adds "accesskey" attribute to:

1. New button on index pages: this way, if you are in Firefox, you can press Alt + Shift + N and go to Add page

2. Save button on form: this way, if you are in Firefox, you can press Alt + Shift + S and submit the form

These two are the main actions I could think to link, but this might be improvable with some others key - action mappings.

Saludos,